### PR TITLE
fix: various fixes to our frontmatter type spec

### DIFF
--- a/frontmatter.ts
+++ b/frontmatter.ts
@@ -5,31 +5,39 @@ interface CoreFrontMatter {
   title: string;
 }
 
-interface CommonFrontMatter extends CoreFrontMatter {
-  deprecated?: boolean;
-  metadata: {
-    description: string;
-    excerpt: string;
-    image: string;
-    keywords: string[];
-    robots: 'index' | 'noindex';
-    /** @example This is the SEO title. */
-    title: string;
-  };
+interface MetadataFrontmatter {
+  description: string;
+  excerpt: string;
+  image: string;
+  keywords: string[];
+  robots: 'index' | 'noindex';
+  /** @example This is the SEO title. */
+  title: string;
 }
 
-export type PageFrontmatter = SetRequired<PartialDeep<CommonFrontMatter>, 'title'> & {
+interface CommonPageFrontmatter extends CoreFrontMatter {
+  deprecated?: boolean;
+  metadata: MetadataFrontmatter;
+}
+
+export type PageFrontmatter = SetRequired<PartialDeep<CommonPageFrontmatter>, 'title'> & {
   link: {
     new_tab: boolean;
     url: string;
   };
 };
 
-export type CustomPageFrontmatter = SetRequired<PartialDeep<CommonFrontMatter>, 'title'> &  {
+export type CustomPageFrontmatter = SetRequired<
+  PartialDeep<
+    // Custom pages have everything that a common page has except that they can't be deprecated.
+    Omit<CommonPageFrontmatter, 'deprecated'>
+  >,
+  'title'
+> & {
   fullscreen: boolean;
 };
 
-export type APIFrontMatter = SetRequired<PartialDeep<CommonFrontMatter>, 'title'> & {
+export type APIFrontMatter = SetRequired<PartialDeep<CommonPageFrontmatter>, 'title'> & {
   api: {
     file: string;
     operationId: string;
@@ -37,7 +45,8 @@ export type APIFrontMatter = SetRequired<PartialDeep<CommonFrontMatter>, 'title'
   };
 };
 
-export type RecipeFrontMatter = SetRequired<PartialDeep<CommonFrontMatter>, 'title'> & {
+export type RecipeFrontMatter = SetRequired<PartialDeep<CoreFrontMatter>, 'title'> & {
+  metadata: PartialDeep<Pick<MetadataFrontmatter, 'description' | 'title'>>;
   recipes: {
     color: `#${string}`;
     icon: string;


### PR DESCRIPTION
## 🧰 Changes

* [x] Splitting `link` types out to only be a part of pages
* [x] Moving `deprecated` to only be possible on pages and apis.
* [x] Adding support for `metadata.title` and `metadata.description` on recipes.