### PR TITLE
feat: frontmatter updates to support recipe <-> reference connections

### DIFF
--- a/frontmatter.schema.json
+++ b/frontmatter.schema.json
@@ -57,6 +57,13 @@
             },
             "required": ["file", "operationId"]            ,
             "description": "Information about the API operation that this page is documenting. If this is `null` or otherwise nonexistent then this page will be a standard page."
+          },
+          "recipes": {
+            "type": ["array", "null"],
+            "items": {
+              "type": "string"
+            },
+            "description": "A list of recipes that this API reference is associated with."
           }
         }
       ]


### PR DESCRIPTION
## 🧰 Changes

In order to facilitate presenting related recipes on API reference pages we need a new frontmatter piece to store that so this adds a `recipes` array into our API reference frontmatter definition.